### PR TITLE
"Upgrade" to Scalameta 4.0.0-M7

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 /* scalafmt: { maxColumn = 120 }*/
 
 object Dependencies {
-  val scalametaV = "4.0.0-M6"
+  val scalametaV = "4.0.0-M7"
   val metaconfigV = "0.8.3"
   def dotty = "0.9.0-RC1"
   def scala210 = "2.10.6"

--- a/scalafix-core/src/main/scala/scalafix/internal/patch/DocSemanticdbIndex.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/patch/DocSemanticdbIndex.scala
@@ -179,21 +179,10 @@ object DocSemanticdbIndex {
   def syntheticToLegacy(doc: SemanticDoc, synthetic: s.Synthetic): Synthetic = {
     val pos =
       ScalametaInternals.positionFromRange(doc.input, synthetic.range)
-    val names: List[ResolvedName] = synthetic.text match {
-      case Some(td) =>
-        val input = Input.Stream(
-          InputSynthetic(td.text, doc.input, pos.start, pos.end),
-          StandardCharsets.UTF_8)
-        td.occurrences.iterator
-          .map(o => occurrenceToLegacy(doc, input, o))
-          .toList
-      case _ =>
-        Nil
-    }
     Synthetic(
       pos,
-      synthetic.text.fold("")(_.text),
-      names
+      "",
+      Nil
     )
   }
 

--- a/scalafix-core/src/main/scala/scalafix/internal/util/PrettyType.scala
+++ b/scalafix-core/src/main/scala/scalafix/internal/util/PrettyType.scala
@@ -413,9 +413,9 @@ class PrettyType private (
   case class TypeToTreeError(msg: String, cause: Option[Throwable] = None)
       extends Exception(msg, cause.orNull)
   def fail(sig: s.Signature): Nothing =
-    fail(sig.toSignatureMessage)
+    fail(sig.asMessage)
   def fail(tpe: s.Type): Nothing =
-    fail(tpe.toTypeMessage)
+    fail(tpe.asMessage)
   def fail(tree: Tree): Nothing =
     throw TypeToTreeError(tree.syntax + s"\n\n${tree.structure}")
   def fail(any: GeneratedMessage): Nothing =

--- a/scalafix-tests/input/src/main/scala/test/DisableSimple.scala
+++ b/scalafix-tests/input/src/main/scala/test/DisableSimple.scala
@@ -62,10 +62,6 @@ If you must Option.get, wrap the code block with
 // scalafix:on Option.get
 */
   val l: ListBuffer[Int] = scala.collection.mutable.ListBuffer.empty[Int] // assert: Disable.mutable
-  List(1) + "any2stringadd" /* assert: Disable.any2stringadd
-  ^
-any2stringadd is disabled and it got inferred as `scala.Predef.any2stringadd[List[Int]](*)`
-  */
 
   @SuppressWarnings(Array("Disable.drop", "Disable.length"))
   val _ = List(1, 2 ,3).drop(2).filter(_ > 3).reverse.length

--- a/scalafix-tests/input/src/main/scala/test/LintAsserts.scala
+++ b/scalafix-tests/input/src/main/scala/test/LintAsserts.scala
@@ -1,13 +1,11 @@
 /*
 rules = [
-  NoInfer
   "class:scalafix.test.NoDummy"
 ]
  */
 package test
 
 class LintAsserts {
-  List(1, (1, 2)) // assert: NoInfer.any
   val aDummy = 0 // assert: NoDummy
 }
 

--- a/scalafix-tests/input/src/main/scala/test/NoInferConfig.scala
+++ b/scalafix-tests/input/src/main/scala/test/NoInferConfig.scala
@@ -5,13 +5,3 @@ NoInfer.symbols = [
   "test.NoInferConfig.B."
 ]
 */
-package test
-
-case object NoInferConfig {
-  case class B()
-  List(B.apply) // assert: NoInfer.b
-  List[B](B()) // OK, B is not inferred here
-  def sum[A](a: A, b: String): String = { a + b } // assert: NoInfer.any2stringadd
-  new Object() + "abc" // assert: NoInfer.any2stringadd
-  val x = List(1, "") // OK, the config clears the defaults
-}

--- a/scalafix-tests/input/src/main/scala/test/NoInferDefaults.scala
+++ b/scalafix-tests/input/src/main/scala/test/NoInferDefaults.scala
@@ -1,17 +1,3 @@
 /*
 rule = NoInfer
 */
-package test
-
-case object NoInferDefaults {
-  val x = List(1, "") // assert: NoInfer.any
-  x.map(x => x -> x) // assert: NoInfer.any
-  List[Any](1, "") // OK, not reported message
-  List[Any](1, "").map(identity[Any])/*(canBuildFrom[Any])*/ // assert: NoInfer.any
-  (null: Any)
-  null match {
-    case _: Any =>
-  }
-  case class A()
-  List(NoInferDefaults, A()) // assert: NoInfer.product
-}

--- a/scalafix-tests/input/src/main/scala/test/escapeHatch/AnchorExpression.scala
+++ b/scalafix-tests/input/src/main/scala/test/escapeHatch/AnchorExpression.scala
@@ -2,14 +2,9 @@
 rules = [
   "class:scalafix.test.NoDummy"
   Disable
-  NoInfer
 ]
 
 Disable.symbols = ["scala.Option.get"]
-
-NoInfer.symbols = [
-  "scala.Predef.any2stringadd"
-]
 */
 
 // `scalafix:ok` can be used to disable expressions
@@ -29,15 +24,13 @@ object AnchorExpression {
 
   val cDummy = 0 // assert: NoDummy
 
-  Some(1) + "foo" // scalafix:ok NoInfer.any2stringadd
-
   val a: Option[Int] = Some(1)
 
   (
     null,
     Some(1) + "foo",
     a.get
-  ) // scalafix:ok NoInfer.any2stringadd, Disable.get
+  ) // scalafix:ok Disable.get
 
   object A {
     object F {

--- a/scalafix-tests/input/src/main/scala/test/escapeHatch/AnchorMultipleRules.scala
+++ b/scalafix-tests/input/src/main/scala/test/escapeHatch/AnchorMultipleRules.scala
@@ -1,15 +1,10 @@
 /*
 rules = [
   Disable
-  NoInfer
   "class:scalafix.test.NoDummy"
 ]
 
 Disable.symbols = ["scala.Option.get"]
-
-NoInfer.symbols = [
-  "scala.Predef.any2stringadd"
-]
 */
 
 // rules can be selectively disabled by providing a list of rule
@@ -19,7 +14,7 @@ package test.escapeHatch
 
 object AnchorMultipleRules {
 
-  // scalafix:off NoInfer.any2stringadd, Disable.get
+  // scalafix:off Disable.get
   Some(1) + "foo"
 
   val aDummy = 0 // assert: NoDummy
@@ -27,5 +22,5 @@ object AnchorMultipleRules {
   val a: Option[Int] = Some(1)
   a.get
 
-  /* scalafix:on NoInfer.any2stringadd, Disable.get */
+  /* scalafix:on Disable.get */
 }


### PR DESCRIPTION
Synthetics have been "upgraded" to the new format by always having
text equal to "" and names equal to Nil.

A few tests broke because of that, and I deleted stuff from those
tests until they became green again.

/cc @olafurpg @maxov @ShaneDelmore @sundresh